### PR TITLE
fix: add `postStartCommand` to start server on reopen

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 			"packages": "gdal-bin,libgdal-dev,build-essential,cmake,apache2,apache2-dev,libapr1-dev,libaprutil1-dev,libjpeg-dev,libpng-dev,zlib1g-dev,libcurl4-openssl-dev,sqlite3,libsqlite3-dev,git"
 		}
 	},
-	"postCreateCommand": "bash setup-ahtse.sh && bash genconf.sh"
+	"postCreateCommand": "bash setup-ahtse.sh && bash genconf.sh",
 
+    "postStartCommand": "sudo service apache2 start"
 }


### PR DESCRIPTION
The startup would fail when you press `Dev Containers: Reopen In Container`